### PR TITLE
Change example from `ci` to `test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+  test:
     uses: 84codes/actions/.github/workflows/ruby-ci.yml@main
     secrets:
       github-token: ${{ secrets.ORG_GITHUB_TOKEN_FOR_CI }}
@@ -37,7 +37,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+  test:
     uses: 84codes/actions/.github/workflows/ruby-ci.yml@main
     with:
       reviewdog: true


### PR DESCRIPTION
For consistency reasons, we use `test` more frequently internally at 84codes.

<!-- Description of the change, references like Slack or Trello links can provide more context -->

### Friendly reminders
- [x] Describe the problem / feature (ideally with [meaningful commit messages](https://tekin.co.uk/2019/02/a-talk-about-revision-histories))
- [ ] Lint rules pass
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] The environment (`heroku config`) has been updated if needed (new `ENV` variables)

### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
