### PR TITLE
Fail build when missing `Gemfile.lock`

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -34,6 +34,11 @@ on:
         default: false
         required: false
         type: boolean
+      bundle-frozen:
+        description: "Value to use for BUNDLE_FROZEN"
+        default: true
+        required: false
+        type: boolean
     secrets:
       github-token:
         description: "GitHub token for private repo dependencies"
@@ -59,7 +64,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         env:
-          BUNDLE_FROZEN: true
+          BUNDLE_FROZEN: ${{ inputs.bundle-frozen }}
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ inputs.pkg-github-com-user }}:${{ secrets.pkg-github-com }}
         with:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         env:
+          BUNDLE_FROZEN: true
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ inputs.pkg-github-com-user }}:${{ secrets.pkg-github-com }}
         with:


### PR DESCRIPTION
https://bundler.io/v2.4/man/bundle-config.1.html

```
$ BUNDLE_FROZEN=1 bundle install
...
Bundle complete! 22 Gemfile dependencies, 40 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

$ rm Gemfile.lock

$ BUNDLE_FROZEN=1 bundle install
The deployment setting requires a Gemfile.lock. Please make sure you have checked your Gemfile.lock into version control before deploying.
```