### PR TITLE
Allow custom run command, change default to `bundle exec rake`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ jobs:
   ruby-ci:
     uses: ./.github/workflows/ruby-ci.yml
     with:
-      run: rake
+      run: |
+        rake
+        uptime
       ruby-version: ruby # latest stable release
       ruby-lint: true
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   ruby-ci:
     uses: ./.github/workflows/ruby-ci.yml
     with:
+      run: rake
       ruby-version: ruby # latest stable release
       ruby-lint: true
     secrets:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -3,6 +3,11 @@ name: Ruby CI
 on:
   workflow_call:
     inputs:
+      run:
+        description: "The command to run (e.g. bundle exec rake)"
+        default: "bundle exec rake"
+        required: false
+        type: string
       ruby-version:
         description: "The Ruby ruby-version to use"
         default: ".ruby-version"
@@ -71,7 +76,7 @@ jobs:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
 
-      - run: bundle exec rake test
+      - run: ${{ inputs.run }}
 
       - name: Setup reviewdog
         if: inputs.reviewdog

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
-task :test
+task :test do
+  puts "Hello, World."
+end
+
 task default: :test


### PR DESCRIPTION
Allows to use the action even if you don't have a bundle (or use `bundler/inline`).

Changes the default from `bundle exec rake test` to `bundle exec rake`, feels more natural.