### PR TITLE
Annotations instead of comments for lint offenses

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -105,6 +105,6 @@ jobs:
         with:
           github_token: ${{ secrets.repo-github-token }}
           level: warning
-          reporter: github-pr-review
+          reporter: github-pr-check
           rubocop_extensions: rubocop-gitlab-security rubocop-performance rubocop-minitest rubocop-eightyfourcodes rubocop-rake rubocop-sequel
           rubocop_flags: -c tools/.rubocop.yml -DEPS


### PR DESCRIPTION
See https://github.com/reviewdog/action-rubocop?tab=readme-ov-file#examples

We have found the comments too annoying and disturbing. Annotations should be less intrusive and when after being resolved, leave no trace.