### PR TITLE
Ruby CI: Use `github-check` lint reporter, avoid linting unrelated files

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -105,6 +105,6 @@ jobs:
         with:
           github_token: ${{ secrets.repo-github-token }}
           level: warning
-          reporter: github-pr-check
+          reporter: github-check
           rubocop_extensions: rubocop-gitlab-security rubocop-performance rubocop-minitest rubocop-eightyfourcodes rubocop-rake rubocop-sequel
           rubocop_flags: -c tools/.rubocop.yml -DEPS

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -96,6 +96,10 @@ jobs:
           repository: 84codes/tools
           token: ${{ secrets.github-token }}
           path: tools
+          # only checkout the lint rules
+          sparse-checkout: |
+            .rubocop.yml
+          sparse-checkout-cone-mode: false
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
* Switches to this reporter so we can have feedback on commits too ([example](https://github.com/84codes/dev-playground84/commit/25203ceb63fc955eddc317bea267f078a5ce67ad)) (not only pull requests): https://github.com/reviewdog/reviewdog?tab=readme-ov-file#reporter-github-checks--reportergithub-check

* Avoids checking out the full tools repo, files from that repo showed up in the lint report ([example](https://github.com/84codes/dev-playground84/actions/runs/7971939827/job/21762665786))