### PR TITLE
Add a parameter `branch` to 84codes/actions/.github/workflows/heroku.yml

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -8,6 +8,11 @@ on:
         default: ${{ github.event.repository.name }}
         required: false
         type: string
+      branch:
+        description: "The branch to deploy"
+        default: ${{ github.event.repository.default_branch }}
+        required: false
+        type: string
     secrets:
       heroku-key:
         description: "Heroku API key (OAuth token)"
@@ -17,7 +22,7 @@ jobs:
   deploy:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == github.event.repository.default_branch
+      github.event.workflow_run.head_branch == inputs.branch
     concurrency: ${{ inputs.heroku-app || github.event.repository.name }}
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +31,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         deploymentId=$(jq -n "{
-            \"ref\": \"${{ github.event.repository.default_branch }}\",\
+            \"ref\": \"${{ inputs.branch }}\",\
             \"environment\": \"${{ inputs.heroku-app }}\",\
             \"description\": \"Heroku deploy from GitHub Actions\",\
             \"required_contexts\": []\
@@ -47,7 +52,7 @@ jobs:
         git fetch --prune --unshallow
         git push --force \
           https://user:$HEROKU_API_KEY@git.heroku.com/${{ inputs.heroku-app }}.git \
-          ${{ github.event.repository.default_branch }}
+          ${{ inputs.branch }}
 
     - name: Create deployment status in GitHub
       if: always()


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes we don't want to deploy to the default branch, but a specific branch instead.

Context: https://trello.com/c/ACLUcB36/92-isolate-deployments-of-cloudamqp

Related PRs:
- https://github.com/84codes/account-console/pull/415
- https://github.com/84codes/customer-console/pull/512

### WHAT is this pull request doing?

#### Example usage

```
jobs:
  deploy-cloud-app:
    uses: 84codes/actions/.github/workflows/heroku.yml@main
    with:
      heroku-app: cloud-app
      branch: specific-branch-name-instead-of-main
```

Notice `branch` inside `with`.

### HOW can this pull request be tested?

I don't know. Merge and see?