### PR TITLE
Don't auto merge default branch into the deploying branch

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         deploymentId=$(jq -n "{
             \"ref\": \"${{ inputs.branch }}\",\
+            \"auto_merge\": \"false\",\
             \"environment\": \"${{ inputs.heroku-app }}\",\
             \"description\": \"Heroku deploy from GitHub Actions\",\
             \"required_contexts\": []\


### PR DESCRIPTION
### WHY are these changes introduced?

After I finished with [this](https://trello.com/c/ACLUcB36/92-isolate-deployments-of-cloudamqp?filter=dateLastActivity:week) I did some post merge QAing.

I wanted to see if pushes to the branch `the-end-is-near` are properly deployed. I noticed the appearance of "Auto-merged main into the-end-is-near on deployment" commit - https://github.com/84codes/account-console/pull/415#issuecomment-2429167602 - which seemed weird.

I got worried if that means that changes made to `main` will get auto merged to `the-end-is-near`, which is not what we want to accomplish with the feature freeze of that branch.

After some digging @dentarg pointed out that we [create a deployment](https://github.com/84codes/actions/blob/d847bb6b9435c706e515f51a8c9f38c683031046/.github/workflows/heroku.yml#L33-L44) and the default value for `auto_merge` field is `true` according to the [docs](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment--parameters) which triggers this behavior.

### WHAT is this pull request doing?

We set `auto_merge` parameter of the deployment to `false`.

When we deploy from the default repo branch this change won't make any difference, there is no need to auto merge the default branch into the branch being deployed since they are the same.

However, if we deploy from a non-default branch - like `the-end-is-near` (that we use for feature freezing legacy apps), then we need to ensure that the default branch (`main`) doesn't get auto merged into the deploying branch (`the-end-is-near`).

### HOW can this pull request be tested?

Merge and see 👀.