### PR TITLE
Keep versions of apt packages

### DIFF
--- a/.github/workflows/upload-apt-pkg.yml
+++ b/.github/workflows/upload-apt-pkg.yml
@@ -84,6 +84,7 @@ jobs:
             --s3-region ${{ inputs.s3-region }} \
             --codename ${{ inputs.codename }} \
             --component main \
+            --preserve-versions
             --arch ${{ inputs.arch }} \
             --sign $GPG_KEY_ID \
             --visibility=nil \


### PR DESCRIPTION
### WHY are these changes introduced?

So one could downgrade stuff if neccessary