### PR TITLE
Lint action relies on rubocop local rubocop cfg

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -92,26 +92,20 @@ jobs:
       - name: Checkout project code
         uses: actions/checkout@v5
 
-      - name: Checkout lint rules
-        uses: actions/checkout@v5
-        with:
-          repository: 84codes/tools
-          token: ${{ secrets.github-token }}
-          path: tools
-          # only checkout the lint rules
-          sparse-checkout: |
-            .rubocop.yml
-          sparse-checkout-cone-mode: false
-
       - uses: ruby/setup-ruby@v1
+        env:
+          BUNDLE_FROZEN: ${{ inputs.bundle-frozen }}
+          BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
+          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ inputs.pkg-github-com-user }}:${{ secrets.pkg-github-com }}
         with:
           ruby-version: ${{ inputs.ruby-version }}
+          bundler-cache: ${{ inputs.bundler-cache }}
+          cache-version: ${{ inputs.cache-version }}
 
       - uses: reviewdog/action-rubocop@v2
         with:
           github_token: ${{ secrets.repo-github-token }}
           level: warning
           reporter: ${{ github.event_name == 'pull_request' && 'github-pr-check' || 'github-check' }}
-          rubocop_version: gemfile
-          rubocop_extensions: rubocop-performance rubocop-minitest rubocop-eightyfourcodes rubocop-rake rubocop-sequel
-          rubocop_flags: -c tools/.rubocop.yml -DEPS
+          skip_install: true
+          use_bundler: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "commons-rubocop", git: "https://github.com/84codes/commons.git", branch: "main"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+desc "Just something we can run in CI testing CI and lint jobs"
 task :test do
   puts "Hello, World."
 end


### PR DESCRIPTION
Opening https://github.com/84codes/actions/pull/27 again because I rushed things 😇 

### WHY are these changes introduced?

Rubocop no longer need to checkout config from tools nor install the cfgs plugins. Each repo provides the config and dependencies.

### WHAT is this pull request doing?

Removes the tools rubocop cfg checkout and arguments.

### HOW was this pull request tested?

Run the action