### PR TITLE
Pass secrets via `secrets:`

### DIFF
--- a/rubocop-lint/README.md
+++ b/rubocop-lint/README.md
@@ -21,7 +21,7 @@ jobs:
 
       # Add linting
       - uses: 84codes/actions/rubocop-lint@main
-        with:
+        secrets:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/rubocop-lint/action.yml
+++ b/rubocop-lint/action.yml
@@ -3,9 +3,6 @@ description: "Run RuboCop linting with reviewdog (assumes Ruby is already set up
 author: "84codes"
 
 inputs:
-  github-token:
-    description: "GitHub token for reviewdog (usually GITHUB_TOKEN)"
-    required: true
   level:
     description: "Report level for reviewdog (info, warning, error)"
     default: "error"
@@ -17,6 +14,9 @@ inputs:
   reporter:
     description: "Reporter type (github-check, github-pr-check, github-pr-review)"
     required: false
+secrets:
+  github-token: # GitHub token for reviewdog (usually GITHUB_TOKEN)
+    required: true
 
 runs:
   using: "composite"
@@ -24,7 +24,7 @@ runs:
     - name: Run RuboCop
       uses: reviewdog/action-rubocop@v2
       with:
-        github_token: ${{ inputs.github-token }}
+        github_token: ${{ secrets.github-token }}
         level: ${{ inputs.level }}
         fail_level: ${{ inputs.fail-level }}
         reporter: ${{ inputs.reporter || (github.event_name == 'pull_request' && 'github-pr-check' || 'github-annotations') }}

--- a/ruby-ci-setup/README.md
+++ b/ruby-ci-setup/README.md
@@ -17,7 +17,7 @@ A composite GitHub Action that sets up everything needed for Ruby CI: PostgreSQL
 ```yaml
 steps:
   - uses: 84codes/actions/ruby-ci-setup@main
-    with:
+    secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -28,6 +28,7 @@ steps:
   - uses: 84codes/actions/ruby-ci-setup@main
     with:
       postgres: true
+    secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -39,6 +40,7 @@ steps:
     with:
       postgres: true
       lavinmq: true
+    secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -60,6 +62,7 @@ jobs:
         with:
           postgres: true
           lavinmq: true
+        secrets:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Multiple test steps - each shows separately in UI
@@ -133,6 +136,6 @@ jobs:
 
 ```yaml
 - uses: 84codes/actions/ruby-ci-setup@main
-  with:
+  secrets:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/ruby-ci-setup/action.yml
+++ b/ruby-ci-setup/action.yml
@@ -30,14 +30,6 @@ inputs:
     description: "Set the working-directory input for setup-ruby"
     default: "."
     required: false
-
-  # GitHub tokens
-  github-token:
-    description: "GitHub token for private repo dependencies"
-    required: false
-  pkg-github-com:
-    description: "Token for rubygems.pkg.github.com"
-    required: false
   pkg-github-com-user:
     description: "GitHub username for rubygems.pkg.github.com auth"
     default: "machine-user-84"
@@ -61,6 +53,12 @@ inputs:
   lavinmq:
     description: "Setup LavinMQ"
     default: "false"
+    required: false
+
+secrets:
+  github-token: # GitHub token for private repo dependencies
+    required: false
+  pkg-github-com: # Token for rubygems.pkg.github.com
     required: false
 
 runs:
@@ -119,8 +117,8 @@ runs:
       uses: ruby/setup-ruby@v1
       env:
         BUNDLE_FROZEN: ${{ inputs.bundle-frozen }}
-        BUNDLE_GITHUB__COM: ${{ inputs.github-token && format('x-access-token:{0}', inputs.github-token) || '' }}
-        BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ inputs.pkg-github-com && format('{0}:{1}', inputs.pkg-github-com-user, inputs.pkg-github-com) || '' }}
+        BUNDLE_GITHUB__COM: ${{ secrets.github-token && format('x-access-token:{0}', secrets.github-token) || '' }}
+        BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.pkg-github-com && format('{0}:{1}', secrets.pkg-github-com-user, secrets.pkg-github-com) || '' }}
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: ${{ inputs.bundler-cache }}


### PR DESCRIPTION
As far as I understand, if you pass ${{ secrets.foo }} to with:, GitHub will mask it because it understands it is a secret. I guess it wont be masked if you pass something that should be secret, but it is not coming from the secrets store.

Also, my understanding is that, this will make us able to do

    secrets: inherit

in calling workflows, if we don't want to pass each secret explicitly (would work for our org secrets as they are named the same in all repos).

Relevant docs:

- https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_callsecrets
- https://docs.github.com/en/actions/reference/security/secure-use
