### PR TITLE
Add shared workflow for Heroku container deploys

### DIFF
--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -13,8 +13,8 @@ on:
         default: ${{ github.event.repository.default_branch }}
         required: false
         type: string
-      process-types:
-        description: "Space-separated Heroku process types to push the image as (e.g. 'web worker')"
+      targets:
+        description: "Space-separated Dockerfile targets to build and push (e.g. 'web worker release')"
         required: true
         type: string
     secrets:
@@ -66,20 +66,11 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: Prepare build inputs
+      - name: Prepare build args
         id: prep
         env:
-          APP: ${{ inputs.heroku-app || github.event.repository.name }}
-          PROCESS_TYPES: ${{ inputs.process-types }}
           BUILD_ARGS: ${{ secrets.build-args }}
         run: |
-          {
-            echo "tags<<EOF"
-            for type in $PROCESS_TYPES; do
-              echo "registry.heroku.com/$APP/$type"
-            done
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
           {
             echo "build-args<<EOF"
             if [ -f .ruby-version ]; then
@@ -91,16 +82,28 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.prep.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: ${{ steps.prep.outputs.build-args }}
-          provenance: false
+      - name: Build and push per process type
+        env:
+          APP: ${{ inputs.heroku-app || github.event.repository.name }}
+          TARGETS: ${{ inputs.targets }}
+          BUILD_ARGS: ${{ steps.prep.outputs.build-args }}
+        run: |
+          build_arg_flags=""
+          while IFS= read -r line; do
+            [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"
+          done <<< "$BUILD_ARGS"
+
+          for target in $TARGETS; do
+            docker buildx build \
+              --target "$target" \
+              --tag "registry.heroku.com/$APP/$target" \
+              --cache-from type=gha \
+              --cache-to type=gha,mode=max \
+              --provenance=false \
+              --push \
+              $build_arg_flags \
+              .
+          done
 
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
@@ -109,8 +112,8 @@ jobs:
         env:
           HEROKU_API_KEY: ${{ secrets.heroku-key }}
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
-          PROCESS_TYPES: ${{ inputs.process-types }}
-        run: heroku container:release $PROCESS_TYPES -a $APP
+          TARGETS: ${{ inputs.targets }}
+        run: heroku container:release $TARGETS -a $APP
 
       - name: Create deployment status in GitHub
         if: always()

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -13,8 +13,8 @@ on:
         default: ${{ github.event.repository.default_branch }}
         required: false
         type: string
-      targets:
-        description: "Space-separated Dockerfile targets to build and push"
+      process-types:
+        description: "Space-separated Heroku process types to push the image as (e.g. 'web worker')"
         required: true
         type: string
     secrets:
@@ -58,35 +58,59 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Log in to Heroku Container Registry
-        run: echo ${{ secrets.heroku-key }} | docker login -u _ --password-stdin registry.heroku.com
+        uses: docker/login-action@v4
+        with:
+          registry: registry.heroku.com
+          username: _
+          password: ${{ secrets.heroku-key }}
 
-      - name: Build and push
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Prepare build inputs
+        id: prep
         env:
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
-          TARGETS: ${{ inputs.targets }}
+          PROCESS_TYPES: ${{ inputs.process-types }}
           BUILD_ARGS: ${{ secrets.build-args }}
         run: |
-          build_arg_flags=""
-          if [ -n "$BUILD_ARGS" ]; then
-            while IFS= read -r line; do
-              [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"
-            done <<< "$BUILD_ARGS"
-          fi
+          {
+            echo "tags<<EOF"
+            for type in $PROCESS_TYPES; do
+              echo "registry.heroku.com/$APP/$type"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "build-args<<EOF"
+            if [ -f .ruby-version ]; then
+              echo "RUBY_VERSION=$(cat .ruby-version)"
+            fi
+            if [ -n "$BUILD_ARGS" ]; then
+              echo "$BUILD_ARGS"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          docker build --target build $build_arg_flags .
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: ${{ steps.prep.outputs.build-args }}
+          provenance: false
 
-          for target in $TARGETS; do
-            docker build --target $target \
-              -t registry.heroku.com/$APP/$target .
-            docker push registry.heroku.com/$APP/$target
-          done
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
 
       - name: Release
         env:
           HEROKU_API_KEY: ${{ secrets.heroku-key }}
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
-          TARGETS: ${{ inputs.targets }}
-        run: heroku container:release $TARGETS -a $APP
+          PROCESS_TYPES: ${{ inputs.process-types }}
+        run: heroku container:release $PROCESS_TYPES -a $APP
 
       - name: Create deployment status in GitHub
         if: always()

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -66,27 +66,11 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: Prepare build args
-        id: prep
-        env:
-          BUILD_ARGS: ${{ secrets.build-args }}
-        run: |
-          {
-            echo "build-args<<EOF"
-            if [ -f .ruby-version ]; then
-              echo "RUBY_VERSION=$(cat .ruby-version)"
-            fi
-            if [ -n "$BUILD_ARGS" ]; then
-              echo "$BUILD_ARGS"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push per process type
+      - name: Build and push per target
         env:
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
           TARGETS: ${{ inputs.targets }}
-          BUILD_ARGS: ${{ steps.prep.outputs.build-args }}
+          BUILD_ARGS: ${{ secrets.build-args }}
         run: |
           build_arg_flags=""
           while IFS= read -r line; do

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -38,33 +38,36 @@ jobs:
       - name: Create deployment in GitHub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ inputs.branch }}
+          APP: ${{ inputs.heroku-app || github.event.repository.name }}
+          REPO: ${{ github.repository }}
         run: |
-          deploymentId=$(jq -n "{
-              \"ref\": \"${{ inputs.branch }}\",\
-              \"auto_merge\": false,\
-              \"environment\": \"${{ inputs.heroku-app }}\",\
-              \"description\": \"Heroku container deploy from GitHub Actions\",\
-              \"required_contexts\": []\
-            }" \
-            | gh api repos/${{ github.repository }}/deployments \
+          deploymentId=$(jq -n \
+            --arg ref "$BRANCH" \
+            --arg env "$APP" \
+            '{ref: $ref, auto_merge: false, environment: $env,
+              description: "Heroku container deploy from GitHub Actions",
+              required_contexts: []}' \
+            | gh api "repos/$REPO/deployments" \
               --method POST \
               --header "Accept: application/vnd.github.v3+json" \
               --input - \
               --jq '.id')
-          echo 'DEPLOYMENT_ID='$deploymentId >> $GITHUB_ENV
+          echo "DEPLOYMENT_ID=$deploymentId" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.branch }}
+          persist-credentials: false
 
       - name: Log in to Heroku Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: registry.heroku.com
           username: _
           password: ${{ secrets.heroku-key }}
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and push per target
         env:
@@ -72,9 +75,9 @@ jobs:
           TARGETS: ${{ inputs.targets }}
           BUILD_ARGS: ${{ secrets.build-args }}
         run: |
-          build_arg_flags=""
+          build_arg_flags=()
           while IFS= read -r line; do
-            [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"
+            [ -n "$line" ] && build_arg_flags+=(--build-arg "$line")
           done <<< "$BUILD_ARGS"
 
           for vfile in .*-version; do
@@ -82,7 +85,7 @@ jobs:
             name="${vfile#.}"
             name="${name%-version}"
             arg_name="$(echo "$name" | tr '[:lower:]-' '[:upper:]_')_VERSION"
-            build_arg_flags="$build_arg_flags --build-arg $arg_name=$(tr -d '[:space:]' < "$vfile")"
+            build_arg_flags+=(--build-arg "$arg_name=$(tr -d '[:space:]' < "$vfile")")
           done
 
           for target in $TARGETS; do
@@ -93,28 +96,34 @@ jobs:
               --cache-to type=gha,mode=max \
               --provenance=false \
               --push \
-              $build_arg_flags \
+              "${build_arg_flags[@]}" \
               .
           done
 
       - name: Install Heroku CLI
-        run: curl https://cli-assets.heroku.com/install.sh | sh
+        run: curl -fsSL https://cli-assets.heroku.com/install.sh | sh
 
       - name: Release
         env:
           HEROKU_API_KEY: ${{ secrets.heroku-key }}
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
           TARGETS: ${{ inputs.targets }}
-        run: heroku container:release $TARGETS -a $APP
+        run: heroku container:release $TARGETS -a "$APP"
 
       - name: Create deployment status in GitHub
-        if: always()
+        if: always() && env.DEPLOYMENT_ID
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          APP: ${{ inputs.heroku-app || github.event.repository.name }}
+          JOB_STATUS: ${{ job.status }}
         run: |
-          gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+          state="$JOB_STATUS"
+          [ "$state" = "cancelled" ] && state="error"
+          gh api "repos/$REPO/deployments/$DEPLOYMENT_ID/statuses" \
             --method POST \
             --header "Accept: application/vnd.github.v3+json" \
-            --field state=${{ job.status }} \
-            --field log_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-            --field environment_url=https://${{ inputs.heroku-app || github.event.repository.name }}.herokuapp.com/
+            --field "state=$state" \
+            --field "log_url=https://github.com/$REPO/actions/runs/$RUN_ID" \
+            --field "environment_url=https://$APP.herokuapp.com/"

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -77,6 +77,14 @@ jobs:
             [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"
           done <<< "$BUILD_ARGS"
 
+          for vfile in .*-version; do
+            [ -f "$vfile" ] || continue
+            name="${vfile#.}"
+            name="${name%-version}"
+            arg_name="$(echo "$name" | tr '[:lower:]-' '[:upper:]_')_VERSION"
+            build_arg_flags="$build_arg_flags --build-arg $arg_name=$(tr -d '[:space:]' < "$vfile")"
+          done
+
           for target in $TARGETS; do
             docker buildx build \
               --target "$target" \

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -1,0 +1,101 @@
+name: Heroku container deploy
+
+on:
+  workflow_call:
+    inputs:
+      heroku-app:
+        description: "The Heroku app name"
+        default: ${{ github.event.repository.name }}
+        required: false
+        type: string
+      branch:
+        description: "The branch to deploy"
+        default: ${{ github.event.repository.default_branch }}
+        required: false
+        type: string
+      targets:
+        description: "Space-separated Dockerfile targets to build and push"
+        required: true
+        type: string
+    secrets:
+      heroku-key:
+        description: "Heroku API key (OAuth token)"
+        required: true
+      build-args:
+        description: "Docker build args (newline-separated KEY=VALUE pairs, typically for private dependency auth)"
+        required: false
+
+jobs:
+  deploy:
+    if: |
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == inputs.branch) ||
+      (github.event_name == 'workflow_dispatch' && github.ref_name == inputs.branch)
+    concurrency: ${{ inputs.heroku-app || github.event.repository.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Create deployment in GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          deploymentId=$(jq -n "{
+              \"ref\": \"${{ inputs.branch }}\",\
+              \"auto_merge\": false,\
+              \"environment\": \"${{ inputs.heroku-app }}\",\
+              \"description\": \"Heroku container deploy from GitHub Actions\",\
+              \"required_contexts\": []\
+            }" \
+            | gh api repos/${{ github.repository }}/deployments \
+              --method POST \
+              --header "Accept: application/vnd.github.v3+json" \
+              --input - \
+              --jq '.id')
+          echo 'DEPLOYMENT_ID='$deploymentId >> $GITHUB_ENV
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Log in to Heroku Container Registry
+        run: echo ${{ secrets.heroku-key }} | docker login -u _ --password-stdin registry.heroku.com
+
+      - name: Build and push
+        env:
+          APP: ${{ inputs.heroku-app || github.event.repository.name }}
+          TARGETS: ${{ inputs.targets }}
+          BUILD_ARGS: ${{ secrets.build-args }}
+        run: |
+          build_arg_flags=""
+          if [ -n "$BUILD_ARGS" ]; then
+            while IFS= read -r line; do
+              [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"
+            done <<< "$BUILD_ARGS"
+          fi
+
+          docker build --target build $build_arg_flags .
+
+          for target in $TARGETS; do
+            docker build --target $target \
+              -t registry.heroku.com/$APP/$target .
+            docker push registry.heroku.com/$APP/$target
+          done
+
+      - name: Release
+        env:
+          HEROKU_API_KEY: ${{ secrets.heroku-key }}
+          APP: ${{ inputs.heroku-app || github.event.repository.name }}
+          TARGETS: ${{ inputs.targets }}
+        run: heroku container:release $TARGETS -a $APP
+
+      - name: Create deployment status in GitHub
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+            --method POST \
+            --header "Accept: application/vnd.github.v3+json" \
+            --field state=${{ job.status }} \
+            --field log_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} \
+            --field environment_url=https://${{ inputs.heroku-app || github.event.repository.name }}.herokuapp.com/

--- a/bin/heroku-container-deploy
+++ b/bin/heroku-container-deploy
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy Docker images to Heroku's container registry.
+# Standalone fallback for when GitHub Actions is unavailable.
+#
+# Usage:
+#   bin/heroku-container-deploy <app> <targets...>
+#   bin/heroku-container-deploy my-app web worker release
+#
+# Build args (for private dependencies) are passed via environment:
+#   BUNDLE_GITHUB__COM=x-access-token:ghp_xxx bin/heroku-container-deploy my-app web worker
+#
+# Requires: docker, heroku CLI, HEROKU_API_KEY env var
+
+if [ $# -lt 2 ]; then
+	echo "Usage: $0 <app> <targets...>" >&2
+	echo "Example: $0 my-app web worker release" >&2
+	exit 1
+fi
+
+APP="$1"
+shift
+TARGETS=("$@")
+
+: "${HEROKU_API_KEY:?Set HEROKU_API_KEY}"
+
+echo "Logging in to Heroku container registry..."
+echo "$HEROKU_API_KEY" | docker login -u _ --password-stdin registry.heroku.com
+
+build_arg_flags=()
+for var in BUNDLE_GITHUB__COM BUNDLE_RUBYGEMS__PKG__GITHUB__COM NPM_TOKEN RUBY_VERSION; do
+	if [ -n "${!var:-}" ]; then
+		build_arg_flags+=(--build-arg "$var=${!var}")
+	fi
+done
+
+for target in "${TARGETS[@]}"; do
+	echo "Building and pushing target: $target"
+	docker build \
+		--target "$target" \
+		--tag "registry.heroku.com/$APP/$target" \
+		--provenance=false \
+		"${build_arg_flags[@]}" \
+		.
+	docker push "registry.heroku.com/$APP/$target"
+done
+
+echo "Releasing: ${TARGETS[*]}"
+heroku container:release "${TARGETS[@]}" -a "$APP"
+
+echo "Done. https://$APP.herokuapp.com/"


### PR DESCRIPTION
## Summary

Shared reusable workflow for repos using Heroku container stack. Builds Docker images in CI and pushes to Heroku's private container registry.

Companion to `heroku.yml` (git-push deploys) for repos that have been containerized.

## Interface

**Inputs:**
- `heroku-app` — Heroku app name (defaults to repo name)
- `branch` — branch to deploy (defaults to default branch)
- `targets` — space-separated Dockerfile build targets (required)

**Secrets:**
- `heroku-key` — Heroku API key (required)
- `build-args` — newline-separated KEY=VALUE pairs for `docker build --build-arg` (optional)

## Usage

```yaml
jobs:
  heroku:
    uses: 84codes/actions/.github/workflows/heroku-container.yml@main
    with:
      targets: "web worker release"
    secrets:
      heroku-key: ${{ secrets.HEROKU_API_KEY }}
      build-args: |
        BUNDLE_GITHUB__COM=x-access-token:${{ secrets.ORG_GITHUB_TOKEN_FOR_CI }}
```

## Test plan

- [ ] Test with billing-and-compliance (84codes/billing-and-compliance#220)