### PR TITLE
Use docker actions for buildx caching and secure login

### DIFF
--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -71,6 +71,7 @@ jobs:
         env:
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
           PROCESS_TYPES: ${{ inputs.process-types }}
+          BUILD_ARGS: ${{ secrets.build-args }}
         run: |
           {
             echo "tags<<EOF"
@@ -79,20 +80,26 @@ jobs:
             done
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-          if [ -f .ruby-version ]; then
-            echo "ruby-version=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo "build-args<<EOF"
+            if [ -f .ruby-version ]; then
+              echo "RUBY_VERSION=$(cat .ruby-version)"
+            fi
+            if [ -n "$BUILD_ARGS" ]; then
+              echo "$BUILD_ARGS"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
+          context: .
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            ${{ steps.prep.outputs.ruby-version != '' && format('RUBY_VERSION={0}', steps.prep.outputs.ruby-version) || '' }}
-            ${{ secrets.build-args }}
+          build-args: ${{ steps.prep.outputs.build-args }}
 
       - name: Release
         env:

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -58,7 +58,13 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Log in to Heroku Container Registry
-        run: echo ${{ secrets.heroku-key }} | docker login -u _ --password-stdin registry.heroku.com
+        uses: docker/login-action@v3
+        with:
+          registry: registry.heroku.com
+          username: _
+          password: ${{ secrets.heroku-key }}
+
+      - uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         env:
@@ -73,12 +79,14 @@ jobs:
             done <<< "$BUILD_ARGS"
           fi
 
-          docker build --target build $build_arg_flags .
-
           for target in $TARGETS; do
-            docker build --target $target \
+            docker buildx build \
+              --target $target \
+              --push \
+              --cache-from type=gha \
+              --cache-to type=gha,mode=max \
+              $build_arg_flags \
               -t registry.heroku.com/$APP/$target .
-            docker push registry.heroku.com/$APP/$target
           done
 
       - name: Release

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -13,8 +13,8 @@ on:
         default: ${{ github.event.repository.default_branch }}
         required: false
         type: string
-      targets:
-        description: "Space-separated Dockerfile targets to build and push"
+      process-types:
+        description: "Space-separated Heroku process types to push the image as (e.g. 'web worker')"
         required: true
         type: string
     secrets:
@@ -69,7 +69,7 @@ jobs:
       - name: Build and push
         env:
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
-          TARGETS: ${{ inputs.targets }}
+          PROCESS_TYPES: ${{ inputs.process-types }}
           BUILD_ARGS: ${{ secrets.build-args }}
         run: |
           build_arg_flags=""
@@ -79,22 +79,24 @@ jobs:
             done <<< "$BUILD_ARGS"
           fi
 
-          for target in $TARGETS; do
-            docker buildx build \
-              --target $target \
-              --push \
-              --cache-from type=gha \
-              --cache-to type=gha,mode=max \
-              $build_arg_flags \
-              -t registry.heroku.com/$APP/$target .
+          tag_flags=""
+          for type in $PROCESS_TYPES; do
+            tag_flags="$tag_flags -t registry.heroku.com/$APP/$type"
           done
+
+          docker buildx build \
+            --push \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            $build_arg_flags \
+            $tag_flags .
 
       - name: Release
         env:
           HEROKU_API_KEY: ${{ secrets.heroku-key }}
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
-          TARGETS: ${{ inputs.targets }}
-        run: heroku container:release $TARGETS -a $APP
+          PROCESS_TYPES: ${{ inputs.process-types }}
+        run: heroku container:release $PROCESS_TYPES -a $APP
 
       - name: Create deployment status in GitHub
         if: always()

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -100,6 +100,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: ${{ steps.prep.outputs.build-args }}
+          provenance: false
 
       - name: Release
         env:

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -66,33 +66,33 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: Build and push
+      - name: Prepare build inputs
+        id: prep
         env:
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
           PROCESS_TYPES: ${{ inputs.process-types }}
-          BUILD_ARGS: ${{ secrets.build-args }}
         run: |
-          build_arg_flags=""
+          {
+            echo "tags<<EOF"
+            for type in $PROCESS_TYPES; do
+              echo "registry.heroku.com/$APP/$type"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
           if [ -f .ruby-version ]; then
-            build_arg_flags="--build-arg RUBY_VERSION=$(cat .ruby-version)"
-          fi
-          if [ -n "$BUILD_ARGS" ]; then
-            while IFS= read -r line; do
-              [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"
-            done <<< "$BUILD_ARGS"
+            echo "ruby-version=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
           fi
 
-          tag_flags=""
-          for type in $PROCESS_TYPES; do
-            tag_flags="$tag_flags -t registry.heroku.com/$APP/$type"
-          done
-
-          docker buildx build \
-            --push \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            $build_arg_flags \
-            $tag_flags .
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            ${{ steps.prep.outputs.ruby-version != '' && format('RUBY_VERSION={0}', steps.prep.outputs.ruby-version) || '' }}
+            ${{ secrets.build-args }}
 
       - name: Release
         env:

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -58,13 +58,13 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Log in to Heroku Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: registry.heroku.com
           username: _
           password: ${{ secrets.heroku-key }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         env:

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -73,6 +73,9 @@ jobs:
           BUILD_ARGS: ${{ secrets.build-args }}
         run: |
           build_arg_flags=""
+          if [ -f .ruby-version ]; then
+            build_arg_flags="--build-arg RUBY_VERSION=$(cat .ruby-version)"
+          fi
           if [ -n "$BUILD_ARGS" ]; then
             while IFS= read -r line; do
               [ -n "$line" ] && build_arg_flags="$build_arg_flags --build-arg $line"


### PR DESCRIPTION
> ● Changes:
> 
>   1. `docker/login-action@v3` — secrets passed via with: instead of shell expansion, avoiding secret exposure in process lists
>   2. `docker/setup-buildx-action@v3` — enables BuildKit with GHA layer caching
>   3. `docker buildx build --push --cache-from type=gha --cache-to type=gha,mode=max` — build + push in one step with cross-run layer caching
>   4. Removed the standalone `docker build --target build warmup` — the GHA cache handles shared layer reuse across targets automatically
> 
>   The reason we still use docker buildx build in a shell loop rather than docker/build-push-action directly: targets are dynamic (space-separated input), and
>   you can't loop over an action step. docker buildx build is the same engine underneath, so caching works identically.