### PR TITLE
Add GitHub Release to container deploy

### DIFF
--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -17,6 +17,11 @@ on:
         description: "Space-separated Dockerfile targets to build and push (e.g. 'web worker release')"
         required: true
         type: string
+      create-release:
+        description: "Create a GitHub Release after successful deploy"
+        default: true
+        required: false
+        type: boolean
     secrets:
       heroku-key:
         description: "Heroku API key (OAuth token)"
@@ -109,6 +114,36 @@ jobs:
           APP: ${{ inputs.heroku-app || github.event.repository.name }}
           TARGETS: ${{ inputs.targets }}
         run: heroku container:release $TARGETS -a "$APP"
+
+      - name: Create GitHub Release
+        if: inputs.create-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          VERSION="v$(date +'%Y.%m.%d-%H%M')"
+          COMMIT_SHA=$(git rev-parse HEAD)
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          RECENT=$(git log --oneline -5 --pretty="- %s (%h)")
+          NOTES=$(cat <<EOF
+          ## Deployed to Production
+
+          **Commit:** ${COMMIT_SHA:0:7}
+          **Time:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+
+          ### Latest Changes
+
+          ${COMMIT_MSG}
+
+          ### Recent Commits
+
+          ${RECENT}
+          EOF
+          )
+          gh release create "$VERSION" \
+            --title "Release $VERSION" \
+            --target "$BRANCH" \
+            --notes "$NOTES"
 
       - name: Create deployment status in GitHub
         if: always() && env.DEPLOYMENT_ID

--- a/.github/workflows/heroku-container.yml
+++ b/.github/workflows/heroku-container.yml
@@ -39,6 +39,9 @@ jobs:
     concurrency: ${{ inputs.heroku-app || github.event.repository.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      deployments: write
     steps:
       - name: Create deployment in GitHub
         env:
@@ -63,6 +66,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.branch }}
+          fetch-depth: 5
           persist-credentials: false
 
       - name: Log in to Heroku Container Registry
@@ -116,12 +120,11 @@ jobs:
         run: heroku container:release $TARGETS -a "$APP"
 
       - name: Create GitHub Release
-        if: inputs.create-release
+        if: inputs['create-release']
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ inputs.branch }}
         run: |
-          VERSION="v$(date +'%Y.%m.%d-%H%M')"
+          VERSION="v$(date -u +'%Y.%m.%d-%H%M%S')"
           COMMIT_SHA=$(git rev-parse HEAD)
           COMMIT_MSG=$(git log -1 --pretty=%B)
           RECENT=$(git log --oneline -5 --pretty="- %s (%h)")
@@ -142,7 +145,7 @@ jobs:
           )
           gh release create "$VERSION" \
             --title "Release $VERSION" \
-            --target "$BRANCH" \
+            --target "$COMMIT_SHA" \
             --notes "$NOTES"
 
       - name: Create deployment status in GitHub


### PR DESCRIPTION
## Summary

- Add optional `create-release` input (default: `true`) to the heroku-container workflow
- After a successful Heroku release, creates a tagged GitHub Release with commit SHA, timestamp, latest commit message, and 5 most recent commits
- Opt out per-repo with `create-release: false`

Ported from 84bot's deploy workflow which had this and it was useful for quick "what just shipped?" visibility in the Releases tab.