### PR TITLE
Add site-preview and site-preview-cleanup composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,49 @@ Run RuboCop linting with reviewdog (assumes Ruby is already set up).
 
 [Read more →](./rubocop-lint/README.md)
 
+### Site Preview Deploy (`site-preview`)
+
+Deploy a built static site to an S3-backed CloudFront preview at `https://pr-<N>.<domain>`. Used by the lavinmq, cloudamqp, and 84codes website repos.
+
+```yaml
+- uses: 84codes/actions/site-preview@main
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    commit-sha: ${{ github.event.pull_request.head.sha }}
+    domain: example.dev
+    cloudfront-distribution-id: EXAMPLEDIST12345
+    csp-policy-name: example-preview-csp-policy
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+[Read more →](./site-preview/README.md)
+
+### Site Preview Cleanup (`site-preview/cleanup`)
+
+Tear down a PR preview: delete the S3 bucket, deactivate the GitHub deployment, comment on the PR.
+
+```yaml
+- uses: 84codes/actions/site-preview/cleanup@main
+  with:
+    pr-number: ${{ github.event.pull_request.number }}
+    domain: example.dev
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+[Read more →](./site-preview/cleanup/README.md)
+
+### Site Preview Prune Orphaned (`site-preview/prune-orphaned`)
+
+Periodic safety net: delete preview buckets older than the cutoff so closed-without-cleanup previews don't accumulate.
+
+```yaml
+- uses: 84codes/actions/site-preview/prune-orphaned@main
+  with:
+    domain: example.dev
+```
+
+[Read more →](./site-preview/prune-orphaned/README.md)
+
 ---
 
 ## Example: Complete Ruby CI Workflow

--- a/site-preview/README.md
+++ b/site-preview/README.md
@@ -1,0 +1,70 @@
+# site-preview
+
+Deploy a built static site to an S3-backed CloudFront preview at `https://pr-<N>.<domain>`. Used by the lavinmq, cloudamqp, and 84codes website repos so the preview pipeline stays in one place.
+
+Assumes AWS credentials are already configured (via `aws-actions/configure-aws-credentials`) and that `<site-dir>` (default `_site`) contains the built site.
+
+## What it does
+
+1. Ensures the per-PR S3 bucket exists (creates it with public-read, website-config, `VantaNonProd` tag, and a 30-day lifecycle rule on first run).
+2. `aws s3 sync`s `<site-dir>` into the bucket.
+3. Detects whether `csp-policy.json` changed in the PR (via `gh pr view --json files`). If it did, attaches the named CloudFront response-headers policy to the preview distribution (creating it if missing).
+4. Invalidates the preview distribution.
+5. Posts (or updates) a comment on the PR with the preview URL.
+
+## Inputs
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `pr-number` | yes | Used to derive `pr-<N>.<domain>` |
+| `commit-sha` | yes | Shown in the PR comment |
+| `domain` | yes | Domain suffix, e.g. `lavinmq.dev` |
+| `cloudfront-distribution-id` | yes | Preview distribution to invalidate and attach CSP to |
+| `csp-policy-name` | yes | Response-headers policy name (created if missing) |
+| `github-token` | yes | `GITHUB_TOKEN` with `pull-requests: write` |
+| `site-dir` | no | Built site directory (default `_site`) |
+| `csp-policy-file` | no | Path to CSP JSON in the caller repo (default `csp-policy.json`) |
+| `comment-marker` | no | Substring used to find/update existing preview comment (default `Preview deployment`) |
+
+## Usage
+
+```yaml
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    environment:
+      name: pr-${{ github.event.pull_request.number }}
+      url: https://pr-${{ github.event.pull_request.number }}.example.dev
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # ... build steps that produce _site/ ...
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::<acct>:role/<role>
+          aws-region: us-east-1
+
+      - uses: 84codes/actions/site-preview@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          commit-sha: ${{ github.event.pull_request.head.sha }}
+          domain: example.dev
+          cloudfront-distribution-id: EXAMPLEDIST12345
+          csp-policy-name: example-preview-csp-policy
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The caller workflow handles triggers, permissions, AWS auth, and the site build. This action handles the bits that are identical across the three site repos.
+
+## Related actions
+
+- [`site-preview/cleanup`](./cleanup) — tear down a preview when its PR closes (delete bucket, delete GitHub environment, comment on the PR).
+- [`site-preview/prune-orphaned`](./prune-orphaned) — scheduled safety net for previews that escaped normal cleanup.

--- a/site-preview/action.yml
+++ b/site-preview/action.yml
@@ -1,0 +1,171 @@
+name: "Site Preview Deploy"
+description: "Deploy a static site to an S3-backed CloudFront preview at pr-N.<domain>. Idempotent: ensures bucket exists, syncs site, attaches CSP policy if changed, invalidates cache, comments PR."
+author: "84codes"
+
+inputs:
+  pr-number:
+    description: "Pull request number, used to derive the bucket and URL"
+    required: true
+  commit-sha:
+    description: "Commit SHA being deployed, surfaced in the PR comment"
+    required: true
+  domain:
+    description: "Preview domain suffix. Previews land at https://pr-<pr-number>.<domain> and on the bucket pr-<pr-number>.<domain>"
+    required: true
+  cloudfront-distribution-id:
+    description: "CloudFront distribution ID that fronts the preview bucket"
+    required: true
+  csp-policy-name:
+    description: "Response headers policy name to attach (created if missing). Skipped unless csp-policy.json changed in the PR."
+    required: true
+  github-token:
+    description: "GITHUB_TOKEN with pull-requests: write (for the comment) and contents: read (for change detection)"
+    required: true
+  site-dir:
+    description: "Directory of the built site to sync"
+    default: "_site"
+  csp-policy-file:
+    description: "Path to the CSP policy JSON in the caller repo, used both to detect changes and as input when updating the policy"
+    default: "csp-policy.json"
+  comment-marker:
+    description: "Substring used to find and update an existing preview comment instead of posting a new one"
+    default: "Preview deployment"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Ensure preview bucket exists
+      shell: bash
+      env:
+        BUCKET: pr-${{ inputs.pr-number }}.${{ inputs.domain }}
+      run: |
+        if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+          echo "Bucket $BUCKET already exists"
+          aws s3api put-bucket-tagging --bucket "$BUCKET" \
+            --tagging 'TagSet=[{Key=VantaNonProd,Value=true}]'
+          exit 0
+        fi
+
+        echo "Creating bucket: $BUCKET"
+        aws s3api create-bucket --bucket "$BUCKET" --region us-east-1
+
+        aws s3api put-bucket-tagging --bucket "$BUCKET" \
+          --tagging 'TagSet=[{Key=VantaNonProd,Value=true}]'
+
+        aws s3api put-bucket-website --bucket "$BUCKET" \
+          --website-configuration '{
+            "IndexDocument": {"Suffix": "index.html"},
+            "ErrorDocument": {"Key": "404.html"}
+          }'
+
+        aws s3api put-public-access-block --bucket "$BUCKET" \
+          --public-access-block-configuration \
+            "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+        aws s3api put-bucket-policy --bucket "$BUCKET" --policy "{
+          \"Version\": \"2012-10-17\",
+          \"Statement\": [{
+            \"Sid\": \"PublicReadGetObject\",
+            \"Effect\": \"Allow\",
+            \"Principal\": \"*\",
+            \"Action\": \"s3:GetObject\",
+            \"Resource\": \"arn:aws:s3:::$BUCKET/*\"
+          }]
+        }"
+
+        aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" \
+          --lifecycle-configuration '{
+            "Rules": [{
+              "ID": "AutoExpire",
+              "Status": "Enabled",
+              "Filter": {},
+              "Expiration": {"Days": 30}
+            }]
+          }'
+
+    - name: Deploy to S3
+      shell: bash
+      env:
+        BUCKET: pr-${{ inputs.pr-number }}.${{ inputs.domain }}
+        SITE_DIR: ${{ inputs.site-dir }}
+      run: aws s3 sync "$SITE_DIR/" "s3://$BUCKET/" --delete
+
+    - name: Detect CSP policy changes
+      id: csp
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPO: ${{ github.repository }}
+        CSP_FILE: ${{ inputs.csp-policy-file }}
+      run: |
+        if gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' \
+            | grep -qx "$CSP_FILE"; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Update preview CSP
+      if: steps.csp.outputs.changed == 'true'
+      shell: bash
+      env:
+        CSP_POLICY_NAME: ${{ inputs.csp-policy-name }}
+        DISTRIBUTION_ID: ${{ inputs.cloudfront-distribution-id }}
+        CSP_POLICY_FILE: ${{ inputs.csp-policy-file }}
+      run: |
+        "${{ github.action_path }}/update-cloudfront-csp.sh" "$CSP_POLICY_NAME" \
+          --create-if-missing \
+          --attach-to "$DISTRIBUTION_ID"
+
+    - name: Invalidate CloudFront cache
+      shell: bash
+      env:
+        DISTRIBUTION_ID: ${{ inputs.cloudfront-distribution-id }}
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id "$DISTRIBUTION_ID" \
+          --paths "/*" \
+          --query 'Invalidation.Id' \
+          --output text
+
+    - name: Comment PR with preview URL
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        REPO: ${{ github.repository }}
+        DOMAIN: ${{ inputs.domain }}
+        MARKER: ${{ inputs.comment-marker }}
+      run: |
+        PREVIEW_URL="https://pr-${PR_NUMBER}.${DOMAIN}"
+
+        COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+
+        COMMENT_BODY=$(cat <<EOF
+        ## Preview deployment ready!
+
+        Your preview is available at:
+        **${PREVIEW_URL}**
+
+        This preview:
+        - Deploys automatically on every commit
+        - Has noindex headers (won't be indexed by search engines)
+        - Will be cleaned up when the PR is closed
+
+        ---
+        *Preview for commit: ${COMMIT_SHA}*
+        EOF
+        )
+
+        if [ -n "$COMMENT_ID" ]; then
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+            --method PATCH \
+            --field body="$COMMENT_BODY"
+        else
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --method POST \
+            --field body="$COMMENT_BODY"
+        fi

--- a/site-preview/cleanup/README.md
+++ b/site-preview/cleanup/README.md
@@ -1,0 +1,50 @@
+# site-preview/cleanup
+
+Tear down a PR preview created by [`site-preview`](..). Deletes the per-PR S3 bucket, deletes the matching GitHub deployment environment, and comments on the PR.
+
+Idempotent: safe to re-run, and the bucket-not-found / env-not-found cases are treated as success.
+
+Assumes AWS credentials are already configured.
+
+## Token requirement
+
+`DELETE /repos/{owner}/{repo}/environments/{name}` requires **`administration: write`** scope on the repository. The default `GITHUB_TOKEN` does NOT have that scope — calls return HTTP 403, no matter what `permissions:` you set in the workflow.
+
+Pass a PAT or GitHub App token (e.g. `secrets.ORG_GITHUB_TOKEN_FOR_CI`) as `github-token` instead. The action surfaces non-404 errors so misconfigured tokens fail loudly rather than silently letting environments pile up.
+
+## Inputs
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `pr-number` | yes | PR number whose preview should be torn down |
+| `domain` | yes | Domain suffix; the bucket `pr-<pr-number>.<domain>` is deleted |
+| `github-token` | yes | Token with `administration: write` and `pull-requests: write`. Default `GITHUB_TOKEN` does NOT work. |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `status` | `deleted`, `not_found`, or `failed` |
+
+## Usage
+
+```yaml
+jobs:
+  cleanup-preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::<acct>:role/<role>
+          aws-region: us-east-1
+
+      - uses: 84codes/actions/site-preview/cleanup@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          domain: example.dev
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN_FOR_CI }}
+```

--- a/site-preview/cleanup/action.yml
+++ b/site-preview/cleanup/action.yml
@@ -1,0 +1,86 @@
+name: "Site Preview Cleanup"
+description: "Tear down a PR preview: delete the S3 bucket, delete the GitHub deployment environment, and comment on the PR. Idempotent — safe to re-run."
+author: "84codes"
+
+inputs:
+  pr-number:
+    description: "Pull request number whose preview should be torn down"
+    required: true
+  domain:
+    description: "Preview domain suffix. The bucket pr-<pr-number>.<domain> is deleted."
+    required: true
+  github-token:
+    description: "Token with `administration: write` (to DELETE the environment) and `pull-requests: write` (to comment). The default GITHUB_TOKEN does NOT work — DELETE /environments requires admin scope. Pass a PAT or GitHub App token (e.g. secrets.ORG_GITHUB_TOKEN_FOR_CI)."
+    required: true
+
+outputs:
+  status:
+    description: "deleted | not_found | failed"
+    value: ${{ steps.bucket.outputs.status }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Delete preview S3 bucket
+      id: bucket
+      shell: bash
+      env:
+        BUCKET: pr-${{ inputs.pr-number }}.${{ inputs.domain }}
+      run: |
+        echo "Cleaning up preview bucket: $BUCKET"
+        if aws s3 rb "s3://$BUCKET" --force; then
+          echo "Bucket $BUCKET deleted"
+          echo "status=deleted" >> "$GITHUB_OUTPUT"
+        elif ! aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+          echo "Bucket $BUCKET does not exist"
+          echo "status=not_found" >> "$GITHUB_OUTPUT"
+        else
+          echo "Failed to delete bucket $BUCKET" >&2
+          echo "status=failed" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+    # Requires a token with `administration: write` — the default GITHUB_TOKEN
+    # gets HTTP 403 here. 404 is fine (env never created, e.g. paths-ignore
+    # filtered the deploy); other errors surface so they aren't silently
+    # swallowed and let environments pile up.
+    - name: Delete preview GitHub environment
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        ENV_NAME: pr-${{ inputs.pr-number }}
+      run: |
+        if stderr=$(gh api -X DELETE "repos/${REPO}/environments/${ENV_NAME}" 2>&1 >/dev/null); then
+          echo "Environment ${ENV_NAME} deleted"
+        elif echo "$stderr" | grep -qE 'HTTP 404|Not Found'; then
+          echo "Environment ${ENV_NAME} already absent"
+        else
+          echo "Failed to delete environment ${ENV_NAME}:" >&2
+          echo "$stderr" >&2
+          exit 1
+        fi
+
+    - name: Comment PR with cleanup status
+      if: always() && steps.bucket.outputs.status != 'not_found'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        BUCKET: pr-${{ inputs.pr-number }}.${{ inputs.domain }}
+        STATUS: ${{ steps.bucket.outputs.status }}
+      run: |
+        case "$STATUS" in
+          deleted)
+            BODY="Preview deployment for \`$BUCKET\` has been cleaned up."
+            ;;
+          *)
+            BODY="Failed to clean up preview deployment for \`$BUCKET\`. Manual cleanup may be required."
+            ;;
+        esac
+
+        gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          --method POST \
+          --field body="$BODY"

--- a/site-preview/prune-orphaned/README.md
+++ b/site-preview/prune-orphaned/README.md
@@ -1,0 +1,36 @@
+# site-preview/prune-orphaned
+
+Periodic safety net: delete S3 buckets matching `pr-*.<domain>` whose `CreationDate` is older than `max-age-days` (default 30). The per-bucket lifecycle rule from [`site-preview`](..) empties old buckets after 30 days, but the bucket itself isn't deleted by lifecycle — this action handles that.
+
+Assumes AWS credentials are already configured.
+
+## Inputs
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `domain` | yes | Domain suffix, e.g. `lavinmq.dev`. Only `pr-*.<domain>` buckets are touched. |
+| `max-age-days` | no | Cutoff in days (default `30`) |
+
+## Usage
+
+```yaml
+on:
+  schedule:
+    - cron: '0 3 * * 0'  # weekly Sunday 03:00 UTC
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::<acct>:role/<role>
+          aws-region: us-east-1
+
+      - uses: 84codes/actions/site-preview/prune-orphaned@main
+        with:
+          domain: example.dev
+```

--- a/site-preview/prune-orphaned/action.yml
+++ b/site-preview/prune-orphaned/action.yml
@@ -1,0 +1,37 @@
+name: "Site Preview Prune Orphaned"
+description: "Delete S3 buckets matching pr-*.<domain> older than the cutoff. Used as a periodic safety net so closed-without-cleanup previews don't accumulate indefinitely (S3 lifecycle empties them after 30 days, but only this prunes the buckets themselves)."
+author: "84codes"
+
+inputs:
+  domain:
+    description: "Domain suffix; buckets named pr-*.<domain> are candidates"
+    required: true
+  max-age-days:
+    description: "Buckets older than this (by S3 CreationDate) are deleted"
+    default: "30"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prune old preview buckets
+      shell: bash
+      env:
+        DOMAIN: ${{ inputs.domain }}
+        MAX_AGE_DAYS: ${{ inputs.max-age-days }}
+      run: |
+        echo "Deleting PR preview buckets older than ${MAX_AGE_DAYS} days for *.${DOMAIN}..."
+        CUTOFF=$(date -d "${MAX_AGE_DAYS} days ago" +%s)
+
+        aws s3api list-buckets \
+          --query "Buckets[?starts_with(Name, \`pr-\`) && ends_with(Name, \`.${DOMAIN}\`)].[Name,CreationDate]" \
+          --output text \
+          | while read -r BUCKET DATE; do
+              [ -z "$BUCKET" ] && continue
+
+              if [ "$(date -d "$DATE" +%s)" -lt "$CUTOFF" ]; then
+                echo "Deleting $BUCKET (created $DATE)"
+                aws s3 rb "s3://$BUCKET" --force || true
+              fi
+            done
+
+        echo "Prune complete"

--- a/site-preview/update-cloudfront-csp.sh
+++ b/site-preview/update-cloudfront-csp.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Update CloudFront Response Headers Policy with CSP from csp-policy.json
+#
+# Usage: ./update-cloudfront-csp.sh <policy-id-or-name> [options]
+#
+# Arguments:
+#   policy-id-or-name          Either a policy ID (UUID) or policy name to find/create
+#
+# Options:
+#   --create-if-missing        Create the policy if it doesn't exist (requires name, not ID)
+#   --attach-to <dist-id>      Attach the policy to this CloudFront distribution
+#
+# Environment:
+#   CSP_POLICY_FILE            Path to csp-policy.json (default: csp-policy.json)
+#
+# Examples:
+#   ./update-cloudfront-csp.sh my-csp-policy --create-if-missing --attach-to EXAMPLEDIST12345
+
+set -euo pipefail
+
+POLICY_ID_OR_NAME="$1"
+CREATE_IF_MISSING=""
+ATTACH_TO_DISTRIBUTION=""
+
+if [ -z "$POLICY_ID_OR_NAME" ]; then
+  echo "Usage: $0 <policy-id-or-name> [--create-if-missing] [--attach-to <dist-id>]" >&2
+  exit 1
+fi
+
+shift
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --create-if-missing)
+      CREATE_IF_MISSING="true"
+      shift
+      ;;
+    --attach-to)
+      ATTACH_TO_DISTRIBUTION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+CSP_POLICY_FILE="${CSP_POLICY_FILE:-csp-policy.json}"
+
+if [ ! -f "$CSP_POLICY_FILE" ]; then
+  echo "CSP policy file not found: $CSP_POLICY_FILE" >&2
+  exit 1
+fi
+
+# Build CSP string from JSON directives
+echo "Building CSP from $CSP_POLICY_FILE..."
+CSP_STRING=""
+for directive in $(jq -r '.directives | keys[]' "$CSP_POLICY_FILE"); do
+  values=$(jq -r ".directives.\"$directive\" | join(\" \")" "$CSP_POLICY_FILE")
+  if [ -z "$values" ]; then
+    CSP_STRING="${CSP_STRING}${directive}; "
+  else
+    CSP_STRING="${CSP_STRING}${directive} ${values}; "
+  fi
+done
+CSP_STRING="${CSP_STRING% }"
+echo "CSP: $CSP_STRING"
+
+# Determine if we have an ID or a name
+POLICY_CREATED=""
+if [[ "$POLICY_ID_OR_NAME" =~ ^[0-9a-f-]{36}$ ]]; then
+  POLICY_ID="$POLICY_ID_OR_NAME"
+  echo "Using policy ID: $POLICY_ID"
+else
+  POLICY_NAME="$POLICY_ID_OR_NAME"
+  echo "Looking up policy by name: $POLICY_NAME"
+  POLICY_ID=$(aws cloudfront list-response-headers-policies \
+    --query "ResponseHeadersPolicyList.Items[?ResponseHeadersPolicy.ResponseHeadersPolicyConfig.Name=='${POLICY_NAME}'].ResponseHeadersPolicy.Id | [0]" \
+    --output text 2>/dev/null || echo "None")
+
+  if [ -z "$POLICY_ID" ] || [ "$POLICY_ID" = "None" ]; then
+    if [ -n "$CREATE_IF_MISSING" ]; then
+      echo "Policy not found, creating: $POLICY_NAME"
+
+      POLICY_CONFIG=$(cat <<EOF
+{
+  "Name": "${POLICY_NAME}",
+  "Comment": "CSP policy managed by GitHub Actions",
+  "SecurityHeadersConfig": {
+    "ContentSecurityPolicy": {
+      "Override": true,
+      "ContentSecurityPolicy": "${CSP_STRING}"
+    }
+  }
+}
+EOF
+)
+      RESULT=$(aws cloudfront create-response-headers-policy \
+        --response-headers-policy-config "$POLICY_CONFIG" \
+        --output json)
+      POLICY_ID=$(echo "$RESULT" | jq -r '.ResponseHeadersPolicy.Id')
+      echo "Created policy: $POLICY_ID"
+      POLICY_CREATED="true"
+    else
+      echo "Policy not found: $POLICY_NAME" >&2
+      echo "Use --create-if-missing to create it" >&2
+      exit 1
+    fi
+  else
+    echo "Found policy ID: $POLICY_ID"
+  fi
+fi
+
+# Skip update if we just created the policy
+if [ -z "$POLICY_CREATED" ]; then
+
+echo "Fetching current policy configuration..."
+aws cloudfront get-response-headers-policy \
+  --id "$POLICY_ID" \
+  --output json > /tmp/current-policy.json
+
+ETAG=$(jq -r '.ETag' /tmp/current-policy.json)
+echo "Current ETag: $ETAG"
+
+echo "Updating CSP in policy configuration..."
+jq --arg csp "$CSP_STRING" \
+  '.ResponseHeadersPolicy.ResponseHeadersPolicyConfig.SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy = $csp' \
+  /tmp/current-policy.json > /tmp/updated-policy.json
+
+# Extract config and remove incomplete security header sections
+# AWS requires all mandatory fields when these sections exist
+jq '.ResponseHeadersPolicy.ResponseHeadersPolicyConfig |
+  if .SecurityHeadersConfig.XSSProtection and
+     (.SecurityHeadersConfig.XSSProtection.Override == null or
+      .SecurityHeadersConfig.XSSProtection.Protection == null)
+  then del(.SecurityHeadersConfig.XSSProtection)
+  else . end |
+  if .SecurityHeadersConfig.FrameOptions and
+     (.SecurityHeadersConfig.FrameOptions.Override == null or
+      .SecurityHeadersConfig.FrameOptions.FrameOption == null)
+  then del(.SecurityHeadersConfig.FrameOptions)
+  else . end |
+  if .SecurityHeadersConfig.ReferrerPolicy and
+     (.SecurityHeadersConfig.ReferrerPolicy.Override == null or
+      .SecurityHeadersConfig.ReferrerPolicy.ReferrerPolicy == null)
+  then del(.SecurityHeadersConfig.ReferrerPolicy)
+  else . end |
+  if .SecurityHeadersConfig.ContentTypeOptions and
+     (.SecurityHeadersConfig.ContentTypeOptions.Override == null)
+  then del(.SecurityHeadersConfig.ContentTypeOptions)
+  else . end |
+  if .SecurityHeadersConfig.StrictTransportSecurity and
+     (.SecurityHeadersConfig.StrictTransportSecurity.Override == null or
+      .SecurityHeadersConfig.StrictTransportSecurity.AccessControlMaxAgeSec == null)
+  then del(.SecurityHeadersConfig.StrictTransportSecurity)
+  else . end' \
+  /tmp/updated-policy.json > /tmp/policy-config.json
+
+echo "Updating CloudFront Response Headers Policy..."
+aws cloudfront update-response-headers-policy \
+  --id "$POLICY_ID" \
+  --if-match "$ETAG" \
+  --response-headers-policy-config file:///tmp/policy-config.json \
+  --output json > /tmp/update-result.json
+
+NEW_ETAG=$(jq -r '.ETag' /tmp/update-result.json)
+echo "Policy updated. New ETag: $NEW_ETAG"
+
+rm -f /tmp/current-policy.json /tmp/updated-policy.json /tmp/policy-config.json /tmp/update-result.json
+
+fi
+
+# Attach policy to distribution if requested
+if [ -n "$ATTACH_TO_DISTRIBUTION" ]; then
+  echo "Checking if policy needs to be attached to distribution $ATTACH_TO_DISTRIBUTION..."
+
+  DIST_CONFIG=$(aws cloudfront get-distribution-config --id "$ATTACH_TO_DISTRIBUTION" --output json)
+  CURRENT_POLICY=$(echo "$DIST_CONFIG" | jq -r '.DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId // empty')
+
+  if [ "$CURRENT_POLICY" != "$POLICY_ID" ]; then
+    echo "Attaching policy to distribution..."
+    DIST_ETAG=$(echo "$DIST_CONFIG" | jq -r '.ETag')
+    echo "$DIST_CONFIG" | jq --arg pid "$POLICY_ID" \
+      '.DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId = $pid | .DistributionConfig' \
+      > /tmp/dist-config.json
+
+    aws cloudfront update-distribution \
+      --id "$ATTACH_TO_DISTRIBUTION" \
+      --if-match "$DIST_ETAG" \
+      --distribution-config file:///tmp/dist-config.json \
+      --output json > /dev/null
+
+    rm -f /tmp/dist-config.json
+    echo "Policy attached to distribution"
+  else
+    echo "Policy already attached to distribution"
+  fi
+fi


### PR DESCRIPTION
## Background

The lavinmq, cloudamqp, and 84codes website repos all run nearly identical PR-preview deployment workflows: per-PR S3 bucket → sync built `_site/` → attach CSP policy if changed → invalidate CloudFront → comment on the PR. Plus a teardown when the PR closes, plus a weekly bucket pruner.

A recent fix in lavinmq-website (https://github.com/84codes/lavinmq-website/pull/206, https://github.com/84codes/lavinmq-website/pull/209) cut preview runtime from 11+ min to ~1 min and registered each preview as a real GitHub deployment. That same fix has to land in cloudamqp-website and 84codes-website next — extracting first avoids three near-duplicate copies of the workflow.

## Summary

Three composite actions:

- **`site-preview/`** — ensure bucket, `s3 sync`, conditional CSP attach (skipped unless `csp-policy.json` changed in the PR), CloudFront invalidate, post or update PR comment. Bundles `update-cloudfront-csp.sh` so callers don't keep their own copy.

- **`site-preview-cleanup/`** — delete the bucket (idempotent), `DELETE /repos/{owner}/{repo}/environments/{name}` to remove the per-PR GitHub environment (404 treated as success, other errors surfaced so misconfigured tokens fail loudly), comment on the PR. Requires a token with `administration: write` — the default `GITHUB_TOKEN` returns 403. Probed `secrets.ORG_GITHUB_TOKEN_FOR_CI` (classic PAT, scopes `repo, workflow, write:packages`) against all three website repos; it has the needed access, so callers can pass that directly.

- **`site-preview-prune-orphaned/`** — periodic safety net: delete preview buckets older than the cutoff so closed-without-cleanup previews don't accumulate.

Caller workflows still own triggers, permissions, the `environment:` block (composite actions can't set those), AWS auth, and the site build (which differs per repo — Node+Ruby for lavinmq, Ruby-only for 84codes, a custom `deploy-with-pagefind` Ruby script for cloudamqp).

## Test plan

- [ ] Merge this PR
- [ ] Migrate lavinmq-website (already on the new shape; should slim to a thin caller workflow)
- [ ] Migrate cloudamqp-website
- [ ] Migrate 84codes-website
- [ ] Verify each: preview deploys in ~1-2 min, registers in PR sidebar, cleanup removes the environment without 403