### PR TITLE
Add 7-day gem cooldown to rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 gem "rubocop-eightyfourcodes"


### PR DESCRIPTION
## Background

RubyGems shipped a [cooldown feature](https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html) (Bundler 4.0.13+) that refuses to resolve a gem version until it's been public for at least N days. That window gives the community time to vet new releases and blunts supply-chain attacks that rely on a freshly published malicious version getting pulled in immediately.

## Summary

Adds `cooldown: 7` to the rubygems.org source in the `Gemfile`, so new gem versions must be public for at least 7 days before Bundler resolves to them.

This repo has no committed `Gemfile.lock`, so there's no `BUNDLED WITH` to bump here (unlike the sibling app PRs). The cooldown takes effect whenever this Gemfile is resolved with Bundler 4.0.13+.
