### PR TITLE
Apply redirects.json on site-preview deploys

### DIFF
--- a/site-preview/README.md
+++ b/site-preview/README.md
@@ -7,10 +7,11 @@ Assumes AWS credentials are already configured (via `aws-actions/configure-aws-c
 ## What it does
 
 1. Ensures the per-PR S3 bucket exists (creates it with public-read, website-config, `VantaNonProd` tag, and a 30-day lifecycle rule on first run).
-2. `aws s3 sync`s `<site-dir>` into the bucket.
-3. Detects whether `csp-policy.json` changed in the PR (via `gh pr view --json files`). If it did, attaches the named CloudFront response-headers policy to the preview distribution (creating it if missing).
-4. Invalidates the preview distribution.
-5. Posts (or updates) a comment on the PR with the preview URL.
+2. `aws s3 sync`s `<site-dir>` into the bucket. Keys listed in `redirects.json` are excluded from the sync's `--delete` so the redirect objects survive.
+3. Applies redirects: for each `source -> target` in `redirects.json`, writes an S3 object at `source` carrying the website-redirect-location metadata, so the S3 website endpoint returns a 301. Missing `redirects.json` is a no-op.
+4. Detects whether `csp-policy.json` changed in the PR (via `gh pr view --json files`). If it did, attaches the named CloudFront response-headers policy to the preview distribution (creating it if missing).
+5. Invalidates the preview distribution.
+6. Posts (or updates) a comment on the PR with the preview URL.
 
 ## Inputs
 
@@ -24,6 +25,7 @@ Assumes AWS credentials are already configured (via `aws-actions/configure-aws-c
 | `github-token` | yes | `GITHUB_TOKEN` with `pull-requests: write` |
 | `site-dir` | no | Built site directory (default `_site`) |
 | `csp-policy-file` | no | Path to CSP JSON in the caller repo (default `csp-policy.json`) |
+| `redirects-file` | no | Path to redirects JSON in the caller repo (default `redirects.json`). Missing file is a no-op. |
 | `comment-marker` | no | Substring used to find/update existing preview comment (default `Preview deployment`) |
 
 ## Usage

--- a/site-preview/action.yml
+++ b/site-preview/action.yml
@@ -27,6 +27,9 @@ inputs:
   csp-policy-file:
     description: "Path to the CSP policy JSON in the caller repo, used both to detect changes and as input when updating the policy"
     default: "csp-policy.json"
+  redirects-file:
+    description: "Path to a redirects JSON in the caller repo, shaped {\"source/key.html\": \"/target.html\"}. Each entry becomes an S3 website redirect object on the preview bucket. Missing file is a no-op."
+    default: "redirects.json"
   comment-marker:
     description: "Substring used to find and update an existing preview comment instead of posting a new one"
     default: "Preview deployment"
@@ -88,7 +91,42 @@ runs:
       env:
         BUCKET: pr-${{ inputs.pr-number }}.${{ inputs.domain }}
         SITE_DIR: ${{ inputs.site-dir }}
-      run: aws s3 sync "$SITE_DIR/" "s3://$BUCKET/" --delete
+        REDIRECTS_FILE: ${{ inputs.redirects-file }}
+      run: |
+        # Redirect objects (see "Apply redirects" below) have no counterpart in
+        # SITE_DIR, so a plain `--delete` would wipe them on every run. Exclude
+        # their keys from the sync's delete pass so they survive.
+        excludes=()
+        if [ -f "$REDIRECTS_FILE" ]; then
+          while IFS= read -r key; do
+            excludes+=(--exclude "$key")
+          done < <(jq -r 'keys[]' "$REDIRECTS_FILE")
+        fi
+        aws s3 sync "$SITE_DIR/" "s3://$BUCKET/" --delete "${excludes[@]}"
+
+    - name: Apply redirects
+      shell: bash
+      env:
+        BUCKET: pr-${{ inputs.pr-number }}.${{ inputs.domain }}
+        REDIRECTS_FILE: ${{ inputs.redirects-file }}
+      run: |
+        if [ ! -f "$REDIRECTS_FILE" ]; then
+          echo "No $REDIRECTS_FILE, skipping redirects"
+          exit 0
+        fi
+        # Mirrors production (Website::Deployer#upload): each source key becomes
+        # an empty S3 object carrying the website-redirect-location metadata, so
+        # the S3 website endpoint returns a 301 to the target.
+        count=$(jq -r 'length' "$REDIRECTS_FILE")
+        echo "Applying $count redirects to $BUCKET"
+        while IFS=$'\t' read -r source target; do
+          echo "Redirecting $source -> $target"
+          aws s3api put-object \
+            --bucket "$BUCKET" \
+            --key "$source" \
+            --website-redirect-location "$target" \
+            --content-type "text/html;charset=utf-8" >/dev/null
+        done < <(jq -r 'to_entries[] | "\(.key)\t\(.value)"' "$REDIRECTS_FILE")
 
     - name: Detect CSP policy changes
       id: csp


### PR DESCRIPTION
## Background

The cloudamqp-website static site keeps its URL redirects in a `redirects.json` at the repo root, shaped like `{"docs/nodejs.html": "/docs/javascript.html"}` (keys are S3 object keys, values are targets).

Production and preview deploys diverged on how they handle that file:

- **Production** runs `Website::Deployer#upload`, which reads `redirects.json` and, for each entry, writes an S3 object at the source key carrying `website_redirect_location: target`. The bucket is served via its S3 website endpoint, so that object returns a 301.
- **Preview** runs `deploy-with-pagefind --render-only` (renders `_site/` and exits *before* `upload`), then hands `_site/` to this `site-preview` action. The action only `aws s3 sync`'d the directory and never created any redirect objects.

Result: every redirect 404'd on PR previews while working in production. Preview buckets are served via the S3 website endpoint (Lambda@Edge origin-request points `pr-N.cloudamqp.dev` at the bucket's `s3-website` endpoint), so the native S3 redirect would work if the objects existed.

## Summary

- New optional input `redirects-file` (default `redirects.json`).
- New **Apply redirects** step after the sync. For each `source -> target` it runs `aws s3api put-object --key source --website-redirect-location target --content-type text/html;charset=utf-8`, mirroring production. Missing file is a no-op, so the lavinmq/84codes repos (which don't ship a `redirects.json`) are unaffected.
- The **Deploy to S3** sync now excludes the redirect keys from its `--delete` pass. Those keys have no counterpart in `_site/`, so a plain `--delete` would wipe the redirect objects on every subsequent run; excluding them keeps the redirects stable across deploys.

## Testing

- `python3 yaml.safe_load` on the action: valid.
- `shellcheck` on both extracted `run` scripts: clean.
- Verified the jq parsing against the real 239-entry `redirects.json`: no leading-slash keys, no embedded tabs, tab-delimited `to_entries` parsing is safe.